### PR TITLE
[CI] Revert to use `HEAD` for `bochscpu-build`

### DIFF
--- a/.github/build-bochscpu.bat
+++ b/.github/build-bochscpu.bat
@@ -12,7 +12,7 @@ mkdir bxbuild
 cd bxbuild
 
 REM Use WSL to configure / clone the repositories.
-bash -c "git clone https://github.com/yrp604/bochscpu-build.git && git clone https://github.com/yrp604/bochscpu && git clone https://github.com/yrp604/bochscpu-ffi && cd bochscpu-build && bash prep.sh && cd Bochs/bochs && bash .conf.cpu-msvc"
+bash -c "git clone https://github.com/yrp604/bochscpu-build.git && git clone https://github.com/hugsy/bochscpu.git && git clone https://github.com/yrp604/bochscpu-ffi.git && cd bochscpu-build && bash prep.sh && cd Bochs/bochs && bash .conf.cpu-msvc"
 
 REM Build bochs; libinstrument.a is expected to fail to build so don't freak out.
 REM You can run nmake all-clean to clean up the build.

--- a/.github/build-bochscpu.bat
+++ b/.github/build-bochscpu.bat
@@ -26,7 +26,6 @@ rmdir /s /q ..\..\..\bochscpu\lib
 
 REM Create the libs directory where we stuff all the libs.
 mkdir ..\..\..\bochscpu\lib
-copy memory\libmemory.a ..\..\..\bochscpu\lib\memory.lib
 copy cpu\libcpu.a ..\..\..\bochscpu\lib\cpu.lib
 copy cpu\fpu\libfpu.a ..\..\..\bochscpu\lib\fpu.lib
 copy cpu\avx\libavx.a ..\..\..\bochscpu\lib\avx.lib

--- a/.github/build-bochscpu.bat
+++ b/.github/build-bochscpu.bat
@@ -39,8 +39,8 @@ REM Now its time to build it.
 cd ..\..\..\bochscpu-ffi
 REM cargo clean -p bochscpu shits its pants on my computer so rebuilding everything
 cargo clean
-cargo build
-cargo build --release
+cargo build -j %%NB_CPU%%
+cargo build -j %%NB_CPU%% --release
 
 REM Get back to where we were.
 popd

--- a/.github/build-bochscpu.bat
+++ b/.github/build-bochscpu.bat
@@ -12,7 +12,7 @@ mkdir bxbuild
 cd bxbuild
 
 REM Use WSL to configure / clone the repositories.
-bash -c "git clone https://github.com/yrp604/bochscpu-build.git && git clone https://github.com/yrp604/bochscpu.git && git clone https://github.com/yrp604/bochscpu-ffi.git && cd bochscpu-build && bash prep.sh && cd Bochs/bochs && bash .conf.cpu-msvc"
+bash -c "git clone https://github.com/yrp604/bochscpu-build.git && git clone https://github.com/hugsy/bochscpu.git && git clone https://github.com/yrp604/bochscpu-ffi.git && cd bochscpu-build && bash prep.sh && cd Bochs/bochs && bash .conf.cpu-msvc"
 
 REM Build bochs; libinstrument.a is expected to fail to build so don't freak out.
 REM You can run nmake all-clean to clean up the build.

--- a/.github/build-bochscpu.bat
+++ b/.github/build-bochscpu.bat
@@ -39,8 +39,8 @@ REM Now its time to build it.
 cd ..\..\..\bochscpu-ffi
 REM cargo clean -p bochscpu shits its pants on my computer so rebuilding everything
 cargo clean
-cargo build -j %%NB_CPU%%
-cargo build -j %%NB_CPU%% --release
+cargo build -j %NB_CPU%
+cargo build -j %NB_CPU% --release
 
 REM Get back to where we were.
 popd

--- a/.github/build-bochscpu.bat
+++ b/.github/build-bochscpu.bat
@@ -12,7 +12,7 @@ mkdir bxbuild
 cd bxbuild
 
 REM Use WSL to configure / clone the repositories.
-bash -c "git clone https://github.com/yrp604/bochscpu-build.git && git clone https://github.com/yrp604/bochscpu && git clone https://github.com/yrp604/bochscpu-ffi && cd bochscpu-build && BOCHS_REV=c48a50141b6ade6c6b0744280a598b55d906bb9e bash prep.sh && cd Bochs/bochs && bash .conf.cpu-msvc"
+bash -c "git clone https://github.com/yrp604/bochscpu-build.git && git clone https://github.com/yrp604/bochscpu && git clone https://github.com/yrp604/bochscpu-ffi && cd bochscpu-build && bash prep.sh && cd Bochs/bochs && bash .conf.cpu-msvc"
 
 REM Build bochs; libinstrument.a is expected to fail to build so don't freak out.
 REM You can run nmake all-clean to clean up the build.

--- a/.github/build-bochscpu.bat
+++ b/.github/build-bochscpu.bat
@@ -26,6 +26,7 @@ rmdir /s /q ..\..\..\bochscpu\lib
 
 REM Create the libs directory where we stuff all the libs.
 mkdir ..\..\..\bochscpu\lib
+copy memory\libmemory.a ..\..\..\bochscpu\lib\memory.lib
 copy cpu\libcpu.a ..\..\..\bochscpu\lib\cpu.lib
 copy cpu\fpu\libfpu.a ..\..\..\bochscpu\lib\fpu.lib
 copy cpu\avx\libavx.a ..\..\..\bochscpu\lib\avx.lib

--- a/.github/build-bochscpu.bat
+++ b/.github/build-bochscpu.bat
@@ -12,11 +12,12 @@ mkdir bxbuild
 cd bxbuild
 
 REM Use WSL to configure / clone the repositories.
-bash -c "git clone https://github.com/yrp604/bochscpu-build.git && git clone https://github.com/hugsy/bochscpu.git && git clone https://github.com/yrp604/bochscpu-ffi.git && cd bochscpu-build && bash prep.sh && cd Bochs/bochs && bash .conf.cpu-msvc"
+bash -c "git clone https://github.com/yrp604/bochscpu-build.git && git clone https://github.com/yrp604/bochscpu.git && git clone https://github.com/yrp604/bochscpu-ffi.git && cd bochscpu-build && bash prep.sh && cd Bochs/bochs && bash .conf.cpu-msvc"
 
 REM Build bochs; libinstrument.a is expected to fail to build so don't freak out.
 REM You can run nmake all-clean to clean up the build.
 cd bochscpu-build\Bochs\bochs
+set CL=/MP
 nmake
 
 REM Remove old files in bochscpu.

--- a/.github/build-bochscpu.sh
+++ b/.github/build-bochscpu.sh
@@ -26,6 +26,7 @@ rm -rf ../../../bochscpu/lib
 
 # Create the libs directory where we stuff all the libs.
 mkdir ../../../bochscpu/lib
+cp memory/libmemory.a ../../../bochscpu/lib/libmemory.a
 cp cpu/libcpu.a ../../../bochscpu/lib/libcpu.a
 cp cpu/fpu/libfpu.a ../../../bochscpu/lib/libfpu.a
 cp cpu/avx/libavx.a ../../../bochscpu/lib/libavx.a

--- a/.github/build-bochscpu.sh
+++ b/.github/build-bochscpu.sh
@@ -16,7 +16,6 @@ git clone https://github.com/yrp604/bochscpu
 git clone https://github.com/yrp604/bochscpu-ffi
 
 cd bochscpu-build
-export BOCHS_REV=c48a50141b6ade6c6b0744280a598b55d906bb9e
 bash prep.sh && cd Bochs/bochs && sh .conf.cpu && make || true
 
 # Remove old files in bochscpu.

--- a/.github/build-bochscpu.sh
+++ b/.github/build-bochscpu.sh
@@ -8,6 +8,8 @@ set -e
 
 pushd .
 
+test -z $NB_CPU && NB_CPU=1
+
 mkdir bxbuild
 cd bxbuild
 
@@ -16,7 +18,7 @@ git clone https://github.com/hugsy/bochscpu.git
 git clone https://github.com/yrp604/bochscpu-ffi.git
 
 cd bochscpu-build
-bash prep.sh && cd Bochs/bochs && sh .conf.cpu && make || true
+bash prep.sh && cd Bochs/bochs && sh .conf.cpu && make -j ${NB_CPU}|| true
 
 # Remove old files in bochscpu.
 rm -rf ../../../bochscpu/bochs
@@ -38,8 +40,8 @@ mv bochs ../../bochscpu/bochs
 cd ../../bochscpu-ffi
 
 cargo clean
-cargo build
-cargo build --release
+cargo build -j ${NB_CPU}
+cargo build -j ${NB_CPU} --release
 
 # Get back to where we were.
 popd

--- a/.github/build-bochscpu.sh
+++ b/.github/build-bochscpu.sh
@@ -12,8 +12,8 @@ mkdir bxbuild
 cd bxbuild
 
 git clone https://github.com/yrp604/bochscpu-build.git
-git clone https://github.com/yrp604/bochscpu
-git clone https://github.com/yrp604/bochscpu-ffi
+git clone https://github.com/hugsy/bochscpu.git
+git clone https://github.com/yrp604/bochscpu-ffi.git
 
 cd bochscpu-build
 bash prep.sh && cd Bochs/bochs && sh .conf.cpu && make || true

--- a/.github/build-bochscpu.sh
+++ b/.github/build-bochscpu.sh
@@ -13,7 +13,7 @@ test -z $NB_CPU && NB_CPU=1
 mkdir bxbuild
 cd bxbuild
 
-git clone https://github.com/yrp/bochscpu-build.git
+git clone https://github.com/yrp604/bochscpu-build.git
 git clone https://github.com/hugsy/bochscpu.git
 git clone https://github.com/yrp604/bochscpu-ffi.git
 

--- a/.github/build-bochscpu.sh
+++ b/.github/build-bochscpu.sh
@@ -13,7 +13,7 @@ test -z $NB_CPU && NB_CPU=1
 mkdir bxbuild
 cd bxbuild
 
-git clone https://github.com/yrp604/bochscpu-build.git
+git clone https://github.com/hugsy/bochscpu-build.git
 git clone https://github.com/hugsy/bochscpu.git
 git clone https://github.com/yrp604/bochscpu-ffi.git
 
@@ -26,11 +26,11 @@ rm -rf ../../../bochscpu/lib
 
 # Create the libs directory where we stuff all the libs.
 mkdir ../../../bochscpu/lib
-cp memory/libmemory.a ../../../bochscpu/lib/libmemory.a
-cp cpu/libcpu.a ../../../bochscpu/lib/libcpu.a
-cp cpu/fpu/libfpu.a ../../../bochscpu/lib/libfpu.a
-cp cpu/avx/libavx.a ../../../bochscpu/lib/libavx.a
-cp cpu/cpudb/libcpudb.a ../../../bochscpu/lib/libcpudb.a
+cp -v memory/libmemory.a ../../../bochscpu/lib/libmemory.a
+cp -v cpu/libcpu.a ../../../bochscpu/lib/libcpu.a
+cp -v cpu/fpu/libfpu.a ../../../bochscpu/lib/libfpu.a
+cp -v cpu/avx/libavx.a ../../../bochscpu/lib/libavx.a
+cp -v cpu/cpudb/libcpudb.a ../../../bochscpu/lib/libcpudb.a
 make all-clean
 
 # Now we want to copy the bochs directory over there.

--- a/.github/build-bochscpu.sh
+++ b/.github/build-bochscpu.sh
@@ -12,7 +12,7 @@ mkdir bxbuild
 cd bxbuild
 
 git clone https://github.com/yrp604/bochscpu-build.git
-git clone https://github.com/yrp604/bochscpu.git
+git clone https://github.com/hugsy/bochscpu.git
 git clone https://github.com/yrp604/bochscpu-ffi.git
 
 cd bochscpu-build

--- a/.github/build-bochscpu.sh
+++ b/.github/build-bochscpu.sh
@@ -12,7 +12,7 @@ mkdir bxbuild
 cd bxbuild
 
 git clone https://github.com/yrp604/bochscpu-build.git
-git clone https://github.com/hugsy/bochscpu.git
+git clone https://github.com/yrp604/bochscpu.git
 git clone https://github.com/yrp604/bochscpu-ffi.git
 
 cd bochscpu-build

--- a/.github/build-bochscpu.sh
+++ b/.github/build-bochscpu.sh
@@ -13,7 +13,7 @@ test -z $NB_CPU && NB_CPU=1
 mkdir bxbuild
 cd bxbuild
 
-git clone https://github.com/hugsy/bochscpu-build.git
+git clone https://github.com/yrp/bochscpu-build.git
 git clone https://github.com/hugsy/bochscpu.git
 git clone https://github.com/yrp604/bochscpu-ffi.git
 
@@ -26,7 +26,6 @@ rm -rf ../../../bochscpu/lib
 
 # Create the libs directory where we stuff all the libs.
 mkdir ../../../bochscpu/lib
-cp -v memory/libmemory.a ../../../bochscpu/lib/libmemory.a
 cp -v cpu/libcpu.a ../../../bochscpu/lib/libcpu.a
 cp -v cpu/fpu/libfpu.a ../../../bochscpu/lib/libfpu.a
 cp -v cpu/avx/libavx.a ../../../bochscpu/lib/libavx.a

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   bochscpu:
     env:
-      BOCHS_REV: HEAD
+      BOCHS_REV: c48a50141b6ade6c6b0744280a598b55d906bb9e
     strategy:
       fail-fast: false
       matrix:
@@ -30,7 +30,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: artifact
-        key: bochscpu-${{ matrix.variant.os }}-${{ matrix.variant.arch }}-artifact-win-lin
+        key: bochscpu-${{ matrix.variant.os }}-${{ matrix.variant.arch }}-artifact-win-lin-macos
 
     - uses: microsoft/setup-msbuild@v1
       if: steps.cache-artifacts.outputs.cache-hit != 'true' && matrix.variant.os == 'windows-latest'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,10 +8,13 @@ on:
     tags:
     - 'v*'
 
+env:
+  NB_CPU: 1
+
 jobs:
   bochscpu:
     env:
-      BOCHS_REV: HEAD
+      BOCHS_REV: fcea81a0425e0e4c6726dad46f0f3837789fe06c
     strategy:
       fail-fast: false
       matrix:
@@ -50,7 +53,7 @@ jobs:
     - name: Build BochsCPU (Linux & MacOS)
       if: steps.cache-artifacts.outputs.cache-hit != 'true' && matrix.variant.os != 'windows-latest'
       run: |
-        chmod +x .github/build-bochscpu.sh; .github/build-bochscpu.sh
+        bash .github/build-bochscpu.sh
         mkdir artifact artifact/Release artifact/Debug artifact/RelWithDebInfo
         cp -v bxbuild/bochscpu-ffi/target/release/lib*.a artifact/Release/
         cp -v bxbuild/bochscpu-ffi/target/debug/lib*.a artifact/Debug/
@@ -76,7 +79,6 @@ jobs:
     runs-on: ${{ matrix.variant.os }}
     name: bindings / ${{ matrix.variant.os }} / ${{ matrix.python-version }} / ${{ matrix.variant.config }}
     env:
-      NB_CPU: 1
       CMAKE_FLAGS: ""
     steps:
     - name: Checkout

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   bochscpu:
     env:
-      BOCHS_REV: fcea81a0425e0e4c6726dad46f0f3837789fe06c
+      BOCHS_REV: 8dd9649389c813a189e3f702d58cdedb93730343
       BOCHSCPU_LIBFILE_NUM: 0
     strategy:
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   bochscpu:
     env:
-      BOCHS_REV: 2a3321d01254f9804ad19c84931043a76526480f
+      BOCHS_REV: HEAD
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,6 +15,7 @@ jobs:
   bochscpu:
     env:
       BOCHS_REV: fcea81a0425e0e4c6726dad46f0f3837789fe06c
+      BOCHSCPU_LIBFILE_NUM: 0
     strategy:
       fail-fast: false
       matrix:
@@ -33,7 +34,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: artifact
-        key: bochscpu-${{ matrix.variant.os }}-${{ matrix.variant.arch }}-artifact-win-lin-macos
+        key: bochscpu-cache-${{ matrix.variant.os }}-${{ matrix.variant.arch }}
 
     - uses: microsoft/setup-msbuild@v1
       if: steps.cache-artifacts.outputs.cache-hit != 'true' && matrix.variant.os == 'windows-latest'
@@ -49,6 +50,7 @@ jobs:
         cp -Verbose bxbuild/bochscpu-ffi/target/release/*.lib artifact/release/
         cp -Verbose bxbuild/bochscpu-ffi/target/debug/*.lib artifact/debug/
         cp -Verbose bxbuild/bochscpu-ffi/target/debug/*.lib artifact/relwithdebinfo/
+        echo BOCHSCPU_LIBFILE_NUM=(Get-ChildItem -Path artifact -File -Recurse -Filter '*.lib').Count | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Build BochsCPU (Linux & MacOS)
       if: steps.cache-artifacts.outputs.cache-hit != 'true' && matrix.variant.os != 'windows-latest'
@@ -58,6 +60,11 @@ jobs:
         cp -v bxbuild/bochscpu-ffi/target/release/lib*.a artifact/Release/
         cp -v bxbuild/bochscpu-ffi/target/debug/lib*.a artifact/Debug/
         cp -v bxbuild/bochscpu-ffi/target/debug/lib*.a artifact/RelWithDebInfo/
+        echo "BOCHSCPU_LIBFILE_NUM=$(find artifact -type f -name 'lib*.a' | wc -l)" >> $GITHUB_ENV
+
+    - name: Check Artifact
+      if: ${{ env.BOCHSCPU_LIBFILE_NUM }} == 0
+      run: exit 1
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,18 @@ jobs:
         path: artifact
         key: bochscpu-cache-${{ matrix.variant.os }}-${{ matrix.variant.arch }}
 
+    - if: steps.cache-artifacts.outputs.cache-hit != 'true' && matrix.variant.os == 'windows-latest'
+      run: |
+        echo NB_CPU=$env:NUMBER_OF_PROCESSORS | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
+    - if: steps.cache-artifacts.outputs.cache-hit != 'true' && matrix.variant.os == 'ubuntu-latest'
+      run: |
+        echo "NB_CPU=$(grep -c ^processor /proc/cpuinfo)" >> $GITHUB_ENV
+
+    - if: steps.cache-artifacts.outputs.cache-hit != 'true' && matrix.variant.os == 'macos-latest'
+      run: |
+        echo NB_CPU=$(sysctl -n hw.ncpu) >> $GITHUB_ENV
+
     - uses: microsoft/setup-msbuild@v1
       if: steps.cache-artifacts.outputs.cache-hit != 'true' && matrix.variant.os == 'windows-latest'
 
@@ -109,8 +121,8 @@ jobs:
     - name: Environment Setup (Windows)
       if: matrix.variant.os == 'windows-latest'
       run: |
-        echo "NB_CPU=$env:NUMBER_OF_PROCESSORS" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-        echo "CMAKE_ARCH='-A ${{ matrix.variant.arch }}'" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo NB_CPU=$env:NUMBER_OF_PROCESSORS | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        echo CMAKE_ARCH='-A ${{ matrix.variant.arch }}' | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
         Import-Module .\.github\Invoke-VisualStudio.ps1
         Invoke-VisualStudio2022${{ matrix.variant.arch }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   bochscpu:
     env:
-      BOCHS_REV: 1e92d9ee4e1bfd0f693704ad08ba05872b60ef9f
+      BOCHS_REV: 8dd9649389c813a189e3f702d58cdedb93730343
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
           - {os: macos-latest, arch: x64}
     runs-on: ${{ matrix.variant.os }}
     name: bochscpu / ${{ matrix.variant.os }} / ${{ matrix.variant.arch }}
-    steps:
+    steps :
     - name: Checkout
       uses: actions/checkout@v3
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
         echo "BOCHSCPU_LIBFILE_NUM=$(find artifact -type f -name 'lib*.a' | wc -l)" >> $GITHUB_ENV
 
     - name: Check Artifact
-      if: ${{ env.BOCHSCPU_LIBFILE_NUM }} == 0
+      if: env.BOCHSCPU_LIBFILE_NUM == 0
       run: exit 1
 
     - name: Upload artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ env:
 jobs:
   bochscpu:
     env:
-      BOCHS_REV: 8dd9649389c813a189e3f702d58cdedb93730343
+      BOCHS_REV: 1e92d9ee4e1bfd0f693704ad08ba05872b60ef9f
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,8 @@ on:
 
 jobs:
   bochscpu:
+    env:
+      BOCHS_REV: HEAD
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ jobs:
   bochscpu:
     env:
       BOCHS_REV: 8dd9649389c813a189e3f702d58cdedb93730343
-      BOCHSCPU_LIBFILE_NUM: 0
     strategy:
       fail-fast: false
       matrix:
@@ -50,7 +49,6 @@ jobs:
         cp -Verbose bxbuild/bochscpu-ffi/target/release/*.lib artifact/release/
         cp -Verbose bxbuild/bochscpu-ffi/target/debug/*.lib artifact/debug/
         cp -Verbose bxbuild/bochscpu-ffi/target/debug/*.lib artifact/relwithdebinfo/
-        echo BOCHSCPU_LIBFILE_NUM=(Get-ChildItem -Path artifact -File -Recurse -Filter '*.lib').Count | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
 
     - name: Build BochsCPU (Linux & MacOS)
       if: steps.cache-artifacts.outputs.cache-hit != 'true' && matrix.variant.os != 'windows-latest'
@@ -60,16 +58,12 @@ jobs:
         cp -v bxbuild/bochscpu-ffi/target/release/lib*.a artifact/Release/
         cp -v bxbuild/bochscpu-ffi/target/debug/lib*.a artifact/Debug/
         cp -v bxbuild/bochscpu-ffi/target/debug/lib*.a artifact/RelWithDebInfo/
-        echo "BOCHSCPU_LIBFILE_NUM=$(find artifact -type f -name 'lib*.a' | wc -l)" >> $GITHUB_ENV
-
-    - name: Check Artifact
-      if: env.BOCHSCPU_LIBFILE_NUM == 0
-      run: exit 1
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v3
       with:
-        name: bochscpu-libs-${{ matrix.variant.os }}-${{ matrix.variant.arch }}
+        if-no-files-found: error
+        name: bochscpu-libs-${{ matrix.variant.os }}-${{ matrix.variant.arch }}-${{ env.BOCHS_REV }}
         path: artifact
 
   bindings:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       uses: actions/cache@v3
       with:
         path: artifact
-        key: bochscpu-cache-${{ matrix.variant.os }}-${{ matrix.variant.arch }}
+        key: bochscpu-libs-${{ matrix.variant.os }}-${{ matrix.variant.arch }}-${{ env.BOCHS_REV }}
 
     - if: steps.cache-artifacts.outputs.cache-hit != 'true' && matrix.variant.os == 'windows-latest'
       run: |
@@ -75,7 +75,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         if-no-files-found: error
-        name: bochscpu-libs-${{ matrix.variant.os }}-${{ matrix.variant.arch }}-${{ env.BOCHS_REV }}
+        name: bochscpu-libs-${{ matrix.variant.os }}-${{ matrix.variant.arch }}
         path: artifact
 
   bindings:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   bochscpu:
     env:
-      BOCHS_REV: c48a50141b6ade6c6b0744280a598b55d906bb9e
+      BOCHS_REV: 2a3321d01254f9804ad19c84931043a76526480f
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Since yrp604/bochscpu-build#4 was merged