### PR TITLE
Add support for `Floatx80` new type

### DIFF
--- a/.github/build-bochscpu.bat
+++ b/.github/build-bochscpu.bat
@@ -12,7 +12,7 @@ mkdir bxbuild
 cd bxbuild
 
 REM Use WSL to configure / clone the repositories.
-bash -c "git clone https://github.com/yrp604/bochscpu-build.git && git clone https://github.com/yrp604/bochscpu.git && git clone https://github.com/yrp604/bochscpu-ffi.git && cd bochscpu-build && bash prep.sh && cd Bochs/bochs && bash .conf.cpu-msvc"
+bash -c "git clone https://github.com/yrp604/bochscpu-build.git && git clone https://github.com/hugsy/bochscpu.git && git clone https://github.com/yrp604/bochscpu-ffi.git && cd bochscpu-build && bash prep.sh && cd Bochs/bochs && bash .conf.cpu-msvc"
 
 REM Build bochs; libinstrument.a is expected to fail to build so don't freak out.
 REM You can run nmake all-clean to clean up the build.

--- a/.github/build-bochscpu.ps1
+++ b/.github/build-bochscpu.ps1
@@ -1,0 +1,36 @@
+$ErrorActionPreference = "Stop"
+
+Push-Location
+
+New-Item -ItemType Directory -Name bxbuild
+Set-Location bxbuild
+
+bash -c "
+git clone https://github.com/hugsy/bochscpu-build.git &&
+git clone https://github.com/hugsy/bochscpu.git &&
+git clone https://github.com/hugsy/bochscpu-ffi.git &&
+cd bochscpu-build && bash prep.sh && cd Bochs/bochs && bash .conf.cpu-msvc
+"
+
+Set-Location bochscpu-build\Bochs\bochs
+$env:CL = "/MP"
+nmake
+
+Remove-Item -Recurse -Force -ErrorAction Ignore ..\..\..\bochscpu\bochs
+Remove-Item -Recurse -Force -ErrorAction Ignore ..\..\..\bochscpu\lib
+
+New-Item -ItemType Directory -Name ..\..\..\bochscpu\lib
+Copy-Item cpu\libcpu.a ..\..\..\bochscpu\lib\cpu.lib
+Copy-Item cpu\fpu\libfpu.a ..\..\..\bochscpu\lib\fpu.lib
+Copy-Item cpu\avx\libavx.a ..\..\..\bochscpu\lib\avx.lib
+Copy-Item cpu\cpudb\libcpudb.a ..\..\..\bochscpu\lib\cpudb.lib
+
+New-Item -ItemType Directory -Name ..\..\..\bochscpu\bochs
+robocopy . ..\..\..\bochscpu\bochs /e
+
+Set-Location ..\..\..\bochscpu-ffi
+cargo clean
+cargo build -j $env:NUMBER_OF_PROCESSORS
+cargo build -j $env:NUMBER_OF_PROCESSORS --release
+
+Pop-Location

--- a/.github/build-bochscpu.sh
+++ b/.github/build-bochscpu.sh
@@ -14,7 +14,7 @@ mkdir bxbuild
 cd bxbuild
 
 git clone https://github.com/yrp604/bochscpu-build.git
-git clone https://github.com/yrp604/bochscpu.git
+git clone https://github.com/hugsy/bochscpu.git
 git clone https://github.com/yrp604/bochscpu-ffi.git
 
 cd bochscpu-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,12 +153,12 @@ jobs:
         python -m pip wheel . -w ./wheel
 
     - name: Install
-      if: matrix.python-version == '3.12'
       run: |
         python -m pip install . --user --upgrade
         python -m pip install capstone keystone-engine --user --upgrade
 
     - name: Tests
+      if: matrix.python-version == '3.12'
       run: |
         python examples/long_mode_fibonacci.py
         python examples/real_mode_print_hello_world.py

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -152,6 +152,16 @@ jobs:
         cmake --install ./build --verbose --config ${{ matrix.variant.config }} --prefix ./artifact
         python -m pip wheel . -w ./wheel
 
+    - name: Install
+      run: |
+        python -m pip install . --user --upgrade
+        python -m pip install capstone keystone-engine --user --upgrade
+
+    - name: Tests
+      run: |
+        python examples/long_mode_fibonacci.py
+        python examples/real_mode_print_hello_world.py
+
     - name: Upload artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,7 +153,7 @@ jobs:
         python -m pip wheel . -w ./wheel
 
     - name: Install
-      if: ${{ matrix.python-version }} == '3.12'
+      if: matrix.python-version == '3.12'
       run: |
         python -m pip install . --user --upgrade
         python -m pip install capstone keystone-engine --user --upgrade

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
   bindings:
     needs: bochscpu
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
         variant:
@@ -153,6 +153,7 @@ jobs:
         python -m pip wheel . -w ./wheel
 
     - name: Install
+      if: ${{ matrix.python-version }} == '3.12'
       run: |
         python -m pip install . --user --upgrade
         python -m pip install capstone keystone-engine --user --upgrade

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # bochscpu-python
 
-[![python 3](https://img.shields.io/badge/python-3.8+-cyan)](https://python.org)
 [![Python 3.8+](https://img.shields.io/pypi/v/bochscpu-python.svg)](https://pypi.org/project/bochscpu-python/)
 [![Downloads](https://static.pepy.tech/badge/bochscpu-python)](https://pepy.tech/project/bochscpu-python)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Licence MIT](https://img.shields.io/packagist/l/doctrine/orm.svg?maxAge=2592000?style=plastic)](https://github.com/hugsy/bochscpu-python/blob/main/LICENSE)
+[![Builds](https://github.com/hugsy/bochscpu-python/actions/workflows/build.yml/badge.svg)](https://github.com/hugsy/bochscpu-python/actions/workflows/build.yml)
 
 Python bindings for [@yrp](https://github.com/yrp604/)'s [BochsCPU](https://github.com/yrp604/bochscpu) using [FFI](https://github.com/yrp604/bochscpu-ffi) to easily and accurately emulate x86 code.
 

--- a/bochscpu/bochscpu.hpp
+++ b/bochscpu/bochscpu.hpp
@@ -131,6 +131,14 @@ struct Zmm
     Zmm() = default;
 };
 
+struct Floatx80
+{
+    uint64_t fraction {};
+    uint16_t exp {};
+
+    Floatx80() = default;
+};
+
 struct State
 {
     uint64_t bochscpu_seed {};
@@ -179,7 +187,7 @@ struct State
     uint16_t fpsw {};
     uint16_t fptw {};
     uint16_t fpop {};
-    std::array<uint64_t, 8> fpst {};
+    std::array<Floatx80, 8> fpst {};
     uint32_t mxcsr {};
     uint32_t mxcsr_mask {};
     uint64_t tsc {};
@@ -206,6 +214,8 @@ using bochscpu_cpu_seg_t = Seg;
 using bochscpu_cpu_global_seg_t = GlobalSeg;
 
 using bochscpu_cpu_zmm_t = Zmm;
+
+using bochscpu_cpu_floatx80_t = Floatx80;
 
 using bochscpu_instr_t = const void*;
 

--- a/python/inc/bochscpu.hpp
+++ b/python/inc/bochscpu.hpp
@@ -108,7 +108,6 @@ enum class InstructionType : uint32_t
     BOCHSCPU_INSTR_IS_SYSEXIT       = BOCHSCPU_INSTR_IS_SYSEXIT,
 };
 
-
 enum class HookType : uint32_t
 {
     BOCHSCPU_HOOK_MEM_READ          = BOCHSCPU_HOOK_MEM_READ,
@@ -125,7 +124,6 @@ enum class HookType : uint32_t
     BOCHSCPU_HOOK_TLB_INVVPID       = BOCHSCPU_HOOK_TLB_INVVPID,
     BOCHSCPU_HOOK_TLB_INVPCID       = BOCHSCPU_HOOK_TLB_INVPCID,
 };
-
 
 enum class OpcodeOperationType
 {
@@ -407,16 +405,18 @@ struct CPU
         this->__cpu = ::bochscpu_cpu_new(0);
         if ( !this->__cpu )
             throw std::runtime_error("Invalid CPU ID");
-        dbg("Created CPU#%lu", this->id);
+        dbg("Created CPU#%lu at %#x", this->id, this->__cpu);
     }
 
     ~CPU()
     {
+        dbg("Destroying CPU#%lu at %#x", this->id, this->__cpu);
         ::bochscpu_cpu_delete(this->__cpu);
+        this->__cpu = nullptr;
     }
 
     uint32_t id {0};
-    bochscpu_cpu_t __cpu {};
+    bochscpu_cpu_t __cpu {nullptr};
 };
 } // namespace Cpu
 


### PR DESCRIPTION
Add proper support for new `Floatx80` introduced in yrp604/bochscpu#12 in the `State` structure - without which segfault happened.

